### PR TITLE
Dev/expand accepted syntax

### DIFF
--- a/lib/nodeattr_utils/node_parser.rb
+++ b/lib/nodeattr_utils/node_parser.rb
@@ -29,7 +29,8 @@
 module NodeattrUtils
   module NodeParser
     EXTERNAL_COMMA = /,(?![^\[]*\])/
-    NAME = /\w+/
+    CHAR = /[^\s\=\,\[]/
+    NAME = /#{CHAR}+/
     RANGE = /\[(\d+([,-]\d+)*)\]/ # Exclude invalid: [] [,] [1-] etc...
     SECTION = /#{NAME}(#{RANGE})?/
     GENERAL_REGEX = /\A#{SECTION}(,#{SECTION})*\Z/

--- a/spec/nodeattr_utils/node_parser_spec.rb
+++ b/spec/nodeattr_utils/node_parser_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe NodeattrUtils::NodeParser do
     context 'with a invalid node input' do
       # NB: according to genders' specification '=' is invalid in node names
       [
-        '%%%', 'n[1-9', 'n4]', 'n[c]', 'n[1,c,2]', 'n[2-1]', 'n[-2]', 'n[]',
+        'n[1-9', 'n[c]', 'n[1,c,2]', 'n[2-1]', 'n[-2]', 'n[]',
         'n[1,,2]', 'n[1,-2]', 'n[,]', 'n[-]', 'no=de[1-10]', 'no[de[1-10]',
         'node[1-10]node[1-10]'
       ].each do |node|
@@ -70,7 +70,9 @@ RSpec.describe NodeattrUtils::NodeParser do
     end
 
     context 'with a single node input' do
-      ['node', 'node1', 'node01', 'node*1', 'node1edon'].each do |node|
+      [
+       'node', 'node1', 'node01', 'node*1', 'node1edon', '***', 'n4]'
+      ].each do |node|
         it "returns: [#{node}]" do
           expect_expand(node).to contain_exactly(node)
         end

--- a/spec/nodeattr_utils/node_parser_spec.rb
+++ b/spec/nodeattr_utils/node_parser_spec.rb
@@ -41,9 +41,11 @@ RSpec.describe NodeattrUtils::NodeParser do
     end
 
     context 'with a invalid node input' do
+      # NB: according to genders' specification '=' is invalid in node names
       [
         '%%%', 'n[1-9', 'n4]', 'n[c]', 'n[1,c,2]', 'n[2-1]', 'n[-2]', 'n[]',
-        'n[1,,2]', 'n[1,-2]', 'n[,]', 'n[-]'
+        'n[1,,2]', 'n[1,-2]', 'n[,]', 'n[-]', 'no=de[1-10]', 'no[de[1-10]',
+        'node[1-10]node[1-10]'
       ].each do |node|
         it "#{node.inspect} raises NodeSyntaxError" do
           expect do
@@ -68,7 +70,7 @@ RSpec.describe NodeattrUtils::NodeParser do
     end
 
     context 'with a single node input' do
-      ['node', 'node1', 'node01'].each do |node|
+      ['node', 'node1', 'node01', 'node*1', 'node1edon'].each do |node|
         it "returns: [#{node}]" do
           expect_expand(node).to contain_exactly(node)
         end
@@ -152,6 +154,30 @@ RSpec.describe NodeattrUtils::NodeParser do
     context 'with multiple single nodes' do
       let(:nodes) { ['node', 'slave', 'login'] }
       let(:nodes_string) { nodes.join(',') }
+
+      include_examples 'expands the nodes'
+    end
+
+    context 'with non-standard prefixes' do
+      let(:indices) { [0, 20] }
+      let(:nodes) { index_range(indices).map { |i| "no*de#{i}" } }
+      let(:nodes_string) { "no*de[#{indices.first}-#{indices.last}]" }
+
+      include_examples 'expands the nodes'
+    end
+
+    context 'with suffixes' do
+      let(:indices) { [0, 20] }
+      let(:nodes) { index_range(indices).map { |i| "node#{i}edon" } }
+      let(:nodes_string) { "node[#{indices.first}-#{indices.last}]edon" }
+
+      include_examples 'expands the nodes'
+    end
+
+    context 'with non-standard suffixes' do
+      let(:indices) { [0, 20] }
+      let(:nodes) { index_range(indices).map { |i| "node#{i}edon*" } }
+      let(:nodes_string) { "node[#{indices.first}-#{indices.last}]edon*" }
 
       include_examples 'expands the nodes'
     end

--- a/spec/nodeattr_utils/node_parser_spec.rb
+++ b/spec/nodeattr_utils/node_parser_spec.rb
@@ -183,5 +183,13 @@ RSpec.describe NodeattrUtils::NodeParser do
 
       include_examples 'expands the nodes'
     end
+
+    context 'with a suffix and a discrete range' do
+      let(:indices) { ['0', '00', '1', '02', '3', '4', '6', '007'] }
+      let(:nodes) { indices.map { |i| "node#{i}edon" } }
+      let(:nodes_string) { "node[#{indices.join(',')}]edon" }
+
+      include_examples 'expands the nodes'
+    end
   end
 end


### PR DESCRIPTION
Extends the accepted syntax for nodes when expanding. 

Change accepted characters from regex word chars (alphanumeric and '_') to all non-whitespace characters except '=', ',' and '['.

Also allows nodes to contain suffixes, characters following ranges and carries the suffixes over to the expanded nodes.